### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -56,7 +56,7 @@ jobs:
         run: docker build -t venus .
 
       - name: upload to registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: dkssud9556/venus
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/test-CD.yml
+++ b/.github/workflows/test-CD.yml
@@ -56,7 +56,7 @@ jobs:
         run: docker build -t dkssud9556/venus:test .
 
       - name: upload to registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: dkssud9556/venus
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore